### PR TITLE
feat: 게시글 소프트 삭제 및 30일 만료 게시글 하드 삭제 스케줄러 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,4 @@ functions/lib/
 
 todo.ini
 
-functions/src/migration/
 .claude/*

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,6 +1,5 @@
 import * as functions from 'firebase-functions';
 import { onDocumentCreated, onDocumentDeleted } from 'firebase-functions/v2/firestore';
-import { onSchedule } from 'firebase-functions/v2/scheduler';
 
 // Auth functions
 import { createFirebaseCustomToken } from './auth/customToken';
@@ -14,9 +13,13 @@ import { handleReplyNotification } from './notifications/reply';
 import { handleUserBlocked, handleUserUnblocked } from './triggers/blocking';
 import { handleCommentCreated, handleCommentDeleted } from './triggers/comments';
 import { handleReplyCreated, handleReplyDeleted } from './triggers/replies';
-import { handleUserReport, restoreUserPostsAfterSuspension } from './triggers/reports';
+import { handleUserReport } from './triggers/reports';
 import { handleUserReview } from './triggers/reviews';
 import { deleteUserAndArchive as deleteUserAndArchiveHandler } from './triggers/userManagement';
+
+// Scheduler functions
+import { hardDeleteExpiredPostsScheduler } from './schedulers/hardDeleteExpiredPostsScheduler';
+import { restoreSuspendedUserPostsScheduler } from './schedulers/restoreSuspendedUserPostsScheduler';
 
 // ===============================
 // HTTP Functions
@@ -185,49 +188,5 @@ export const onUnblockUser = onDocumentDeleted(
 // Scheduler Functions
 // ===============================
 
-/**
- * 매일 한국 시간 자정에 실행되는 스케줄러 함수
- * 정지 해제된 사용자들의 게시글 복구 처리
- */
-export const restorePostsScheduler = onSchedule(
-	{
-		schedule: '0 0 * * *',
-		timeZone: 'Asia/Seoul',
-	},
-	async () => {
-		console.log('게시글 복구 스케줄러 시작');
-
-		try {
-			const db = require('./utils/common').db;
-			const now = new Date();
-
-			// 정지 기간이 만료된 사용자들 조회
-			const usersSnapshot = await db
-				.collection('Users')
-				.where('report.suspendUntil', '<=', now)
-				.where('report.suspendUntil', '!=', null)
-				.get();
-
-			console.log(`정지 해제 대상 사용자 수: ${usersSnapshot.size}`);
-
-			// 각 사용자의 게시글 복구 처리
-			for (const userDoc of usersSnapshot.docs) {
-				const userId = userDoc.id;
-
-				// 정지 해제 처리
-				await userDoc.ref.update({
-					'report.suspendUntil': null,
-				});
-
-				// 게시글 복구
-				await restoreUserPostsAfterSuspension(userId);
-
-				console.log(`사용자 ${userId} 정지 해제 및 게시글 복구 완료`);
-			}
-
-			console.log('게시글 복구 스케줄러 완료');
-		} catch (error) {
-			console.error('게시글 복구 스케줄러 실행 중 오류:', error);
-		}
-	},
-);
+export { restoreSuspendedUserPostsScheduler };
+export { hardDeleteExpiredPostsScheduler };

--- a/functions/src/schedulers/hardDeleteExpiredPostsScheduler.ts
+++ b/functions/src/schedulers/hardDeleteExpiredPostsScheduler.ts
@@ -1,0 +1,89 @@
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+
+/**
+ * 매일 한국 시간 새벽 4시에 실행되는 스케줄러 함수
+ * 삭제된지 30일 지난 게시글 하드 삭제 처리
+ */
+export const hardDeleteExpiredPostsScheduler = onSchedule(
+	{
+		schedule: '0 4 * * *',
+		timeZone: 'Asia/Seoul',
+	},
+	async () => {
+		console.log('만료된 삭제 게시글 하드 삭제 스케줄러 시작');
+
+		try {
+			const db = require('../utils/common').db;
+			// Date 객체 생성 및 30일 빼기
+			const thirtyDaysAgo = new Date();
+			thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+			const collections = ['Boards', 'Communities'];
+
+			// 삭제된지 30일 지난 게시글 삭제
+			for (const collectionName of collections) {
+				const snapshot = await db
+					.collection(collectionName)
+					.where('status', '==', 'deleted')
+					.where('deletedAt', '<=', thirtyDaysAgo)
+					.get();
+
+				if (snapshot.empty) {
+					console.log(`${collectionName} 컬렉션: 삭제할 게시글 없음`);
+					continue;
+				}
+
+				console.log(`${collectionName}: 하드 삭제 대상 문서 수 ${snapshot.size}개`);
+
+				let currentBatch = db.batch();
+				let operationCount = 0;
+
+				for (const doc of snapshot.docs) {
+					// 1. Comments 서브컬렉션 조회 및 삭제
+					const commentsSnap = await doc.ref.collection('Comments').get();
+					for (const commentDoc of commentsSnap.docs) {
+						// 2. Replies 서브컬렉션 조회 및 삭제
+						const repliesSnap = await commentDoc.ref.collection('Replies').get();
+						for (const replyDoc of repliesSnap.docs) {
+							currentBatch.delete(replyDoc.ref);
+							operationCount++;
+							if (operationCount >= 490) {
+								// 500 제한 방지
+								await currentBatch.commit();
+								currentBatch = db.batch();
+								operationCount = 0;
+							}
+						}
+
+						currentBatch.delete(commentDoc.ref);
+						operationCount++;
+						if (operationCount >= 490) {
+							await currentBatch.commit();
+							currentBatch = db.batch();
+							operationCount = 0;
+						}
+					}
+
+					// 3. 본 게시글(문서) 삭제
+					currentBatch.delete(doc.ref);
+					operationCount++;
+					if (operationCount >= 490) {
+						await currentBatch.commit();
+						currentBatch = db.batch();
+						operationCount = 0;
+					}
+				}
+
+				if (operationCount > 0) {
+					await currentBatch.commit();
+				}
+
+				console.log(`${collectionName} 하드 삭제 완료`);
+			}
+
+			console.log('만료된 삭제 게시글 하드 삭제 스케줄러 완료');
+		} catch (error) {
+			console.error('만료 게시글 하드 삭제 스케줄러 실행 중 오류:', error);
+		}
+	},
+);

--- a/functions/src/schedulers/hardDeleteExpiredPostsScheduler.ts
+++ b/functions/src/schedulers/hardDeleteExpiredPostsScheduler.ts
@@ -1,5 +1,16 @@
+import * as admin from 'firebase-admin';
 import { onSchedule } from 'firebase-functions/v2/scheduler';
 import { db } from '../utils/common';
+
+/**
+ * Firebase Storage 다운로드 URL에서 파일 경로를 추출
+ * URL 형식: https://firebasestorage.googleapis.com/v0/b/{bucket}/o/{encoded_path}?alt=media&token={token}
+ */
+function extractStoragePath(downloadUrl: string): string | null {
+	const match = downloadUrl.match(/\/o\/(.+?)\?/);
+	if (!match) return null;
+	return decodeURIComponent(match[1]);
+}
 
 /**
  * 매일 한국 시간 새벽 4시에 실행되는 스케줄러 함수
@@ -35,10 +46,27 @@ export const hardDeleteExpiredPostsScheduler = onSchedule(
 
 				console.log(`${collectionName}: 하드 삭제 대상 문서 수 ${snapshot.size}개`);
 
+				const bucket = admin.storage().bucket();
+
 				let currentBatch = db.batch();
 				let operationCount = 0;
 
 				for (const doc of snapshot.docs) {
+					// 게시글의 Storage 이미지 삭제
+					const images: string[] = doc.data().images ?? [];
+					for (const url of images) {
+						try {
+							const path = extractStoragePath(url);
+							if (!path) {
+								console.warn(`유효하지 않은 Storage URL (건너뜀): ${url}`);
+								continue;
+							}
+							await bucket.file(path).delete();
+						} catch (error) {
+							console.error(`이미지 삭제 실패: ${url}`, error);
+						}
+					}
+
 					// 1. Comments 서브컬렉션 조회 및 삭제
 					const commentsSnap = await doc.ref.collection('Comments').get();
 					for (const commentDoc of commentsSnap.docs) {

--- a/functions/src/schedulers/hardDeleteExpiredPostsScheduler.ts
+++ b/functions/src/schedulers/hardDeleteExpiredPostsScheduler.ts
@@ -1,4 +1,5 @@
 import { onSchedule } from 'firebase-functions/v2/scheduler';
+import { db } from '../utils/common';
 
 /**
  * 매일 한국 시간 새벽 4시에 실행되는 스케줄러 함수
@@ -13,7 +14,6 @@ export const hardDeleteExpiredPostsScheduler = onSchedule(
 		console.log('만료된 삭제 게시글 하드 삭제 스케줄러 시작');
 
 		try {
-			const db = require('../utils/common').db;
 			// Date 객체 생성 및 30일 빼기
 			const thirtyDaysAgo = new Date();
 			thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);

--- a/functions/src/schedulers/restoreSuspendedUserPostsScheduler.ts
+++ b/functions/src/schedulers/restoreSuspendedUserPostsScheduler.ts
@@ -1,4 +1,5 @@
 import { onSchedule } from 'firebase-functions/v2/scheduler';
+import { db } from '../utils/common';
 import { restoreUserPostsAfterSuspension } from '../triggers/reports';
 
 /**
@@ -14,7 +15,6 @@ export const restoreSuspendedUserPostsScheduler = onSchedule(
 		console.log('게시글 복구 스케줄러 시작');
 
 		try {
-			const db = require('../utils/common').db;
 			const now = new Date();
 
 			// 정지 기간이 만료된 사용자들 조회

--- a/functions/src/schedulers/restoreSuspendedUserPostsScheduler.ts
+++ b/functions/src/schedulers/restoreSuspendedUserPostsScheduler.ts
@@ -1,0 +1,49 @@
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+import { restoreUserPostsAfterSuspension } from '../triggers/reports';
+
+/**
+ * 매일 한국 시간 자정에 실행되는 스케줄러 함수
+ * 정지 해제된 사용자들의 게시글 복구 처리
+ */
+export const restoreSuspendedUserPostsScheduler = onSchedule(
+	{
+		schedule: '0 0 * * *',
+		timeZone: 'Asia/Seoul',
+	},
+	async () => {
+		console.log('게시글 복구 스케줄러 시작');
+
+		try {
+			const db = require('../utils/common').db;
+			const now = new Date();
+
+			// 정지 기간이 만료된 사용자들 조회
+			const usersSnapshot = await db
+				.collection('Users')
+				.where('report.suspendUntil', '<=', now)
+				.where('report.suspendUntil', '!=', null)
+				.get();
+
+			console.log(`정지 해제 대상 사용자 수: ${usersSnapshot.size}`);
+
+			// 각 사용자의 게시글 복구 처리
+			for (const userDoc of usersSnapshot.docs) {
+				const userId = userDoc.id;
+
+				// 정지 해제 처리
+				await userDoc.ref.update({
+					'report.suspendUntil': null,
+				});
+
+				// 게시글 복구
+				await restoreUserPostsAfterSuspension(userId);
+
+				console.log(`사용자 ${userId} 정지 해제 및 게시글 복구 완료`);
+			}
+
+			console.log('게시글 복구 스케줄러 완료');
+		} catch (error) {
+			console.error('게시글 복구 스케줄러 실행 중 오류:', error);
+		}
+	},
+);

--- a/functions/src/triggers/comments.ts
+++ b/functions/src/triggers/comments.ts
@@ -6,10 +6,7 @@ import { db } from '../utils/common';
  * @param collection - 컬렉션 이름
  * @param postId - 게시글 ID
  */
-export async function handleCommentCreated(
-	collection: string,
-	postId: string,
-): Promise<void> {
+export async function handleCommentCreated(collection: string, postId: string): Promise<void> {
 	const postRef = db.doc(`${collection}/${postId}`);
 
 	try {
@@ -26,13 +23,15 @@ export async function handleCommentCreated(
  * @param collection - 컬렉션 이름
  * @param postId - 게시글 ID
  */
-export async function handleCommentDeleted(
-	collection: string,
-	postId: string,
-): Promise<void> {
+export async function handleCommentDeleted(collection: string, postId: string): Promise<void> {
 	const postRef = db.doc(`${collection}/${postId}`);
 
 	try {
+		// 하드 삭제 스케줄러가 댓글을 batch delete할 때 이 트리거가 발동되므로,
+		// 이미 소프트 삭제된 게시글이면 불필요한 commentCount 감소를 방지
+		const postSnap = await postRef.get();
+		if (!postSnap.exists || postSnap.data()?.status === 'deleted') return;
+
 		await postRef.update({
 			commentCount: FieldValue.increment(-1),
 		});

--- a/functions/src/triggers/replies.ts
+++ b/functions/src/triggers/replies.ts
@@ -27,6 +27,11 @@ export async function handleReplyDeleted(collection: string, postId: string): Pr
 	const postRef = db.doc(`${collection}/${postId}`);
 
 	try {
+		// 하드 삭제 스케줄러가 대댓글을 batch delete할 때 이 트리거가 발동되므로,
+		// 이미 소프트 삭제된 게시글이면 불필요한 commentCount 감소를 방지
+		const postSnap = await postRef.get();
+		if (!postSnap.exists || postSnap.data()?.status === 'deleted') return;
+
 		await postRef.update({
 			commentCount: FieldValue.increment(-1),
 		});

--- a/src/firebase/services/postService.ts
+++ b/src/firebase/services/postService.ts
@@ -16,7 +16,6 @@ import {
 	queryDocs,
 	updateDocToFirestore,
 } from '@/firebase/core/firestoreService';
-import { deleteObjectFromStorage } from '@/firebase/services/imageService';
 import { Collection, CreatePostRequest, Post, PostDoc, UpdatePostRequest } from '@/types/post';
 import { PublicUserInfo } from '@/types/user';
 import { getDefaultUserInfo } from '@/utilities/getDefaultUserInfo';
@@ -184,17 +183,7 @@ export const deletePost = async <C extends Collection>(
 	return firestoreRequest(
 		'게시글 삭제',
 		async () => {
-			// 커뮤니티 게시글인 경우 이미지 삭제
-			if (collectionName === 'Communities') {
-				const post = await getPost(collectionName, postId);
-				if (post && 'images' in post && post.images.length > 0) {
-					await Promise.all(
-						post.images.map((imageUrl: string) => deleteObjectFromStorage(imageUrl)),
-					);
-				}
-			}
-
-			// soft delete
+			// 소프트 삭제: 상태만 변경
 			await updateDocToFirestore({
 				collection: collectionName,
 				id: postId,

--- a/src/firebase/services/postService.ts
+++ b/src/firebase/services/postService.ts
@@ -12,11 +12,11 @@ import { db } from '@/config/firebase';
 import firestoreRequest from '@/firebase/core/firebaseInterceptor';
 import {
 	addDocToFirestore,
-	deleteDocFromFirestore,
 	getDocFromFirestore,
 	queryDocs,
 	updateDocToFirestore,
 } from '@/firebase/core/firestoreService';
+import { deleteObjectFromStorage } from '@/firebase/services/imageService';
 import { Collection, CreatePostRequest, Post, PostDoc, UpdatePostRequest } from '@/types/post';
 import { PublicUserInfo } from '@/types/user';
 import { getDefaultUserInfo } from '@/utilities/getDefaultUserInfo';
@@ -184,7 +184,25 @@ export const deletePost = async <C extends Collection>(
 	return firestoreRequest(
 		'게시글 삭제',
 		async () => {
-			await deleteDocFromFirestore({ id: postId, collection: collectionName });
+			// 커뮤니티 게시글인 경우 이미지 삭제
+			if (collectionName === 'Communities') {
+				const post = await getPost(collectionName, postId);
+				if (post && 'images' in post && post.images.length > 0) {
+					await Promise.all(
+						post.images.map((imageUrl: string) => deleteObjectFromStorage(imageUrl)),
+					);
+				}
+			}
+
+			// soft delete
+			await updateDocToFirestore({
+				collection: collectionName,
+				id: postId,
+				requestData: {
+					status: 'deleted',
+					deletedAt: Timestamp.now(),
+				},
+			});
 		},
 		{ throwOnError: true },
 	);

--- a/src/hooks/post/mutation/useDeletePost.ts
+++ b/src/hooks/post/mutation/useDeletePost.ts
@@ -9,6 +9,7 @@ export const useDeletePost = <C extends Collection>(collectionName: C, postId: s
 	return useMutation({
 		mutationFn: () => deletePost(collectionName, postId),
 		onSuccess: () => {
+			queryClient.removeQueries({ queryKey: ['postDetail', collectionName, postId] });
 			queryClient.invalidateQueries({ queryKey: ['posts', collectionName] });
 		},
 	});

--- a/src/hooks/post/query/usePostDetail.ts
+++ b/src/hooks/post/query/usePostDetail.ts
@@ -9,7 +9,8 @@ const fetchPostDetail = async <C extends Collection>(
 	id: string,
 ): Promise<PostWithCreatorInfo<C> | null> => {
 	const post = await getPost(collectionName, id);
-	if (!post) return null;
+	// 숨김/삭제된 게시글은 조회하지 않음
+	if (!post || post.status === 'hidden' || post.status === 'deleted') return null;
 
 	const userInfo = await getPublicUserInfo(post.creatorId);
 

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -69,6 +69,7 @@ export type PostWithCreatorInfo<C extends Collection> = PostMap[C] & CreatorInfo
 // Firestore용 PostDoc
 export type PostDoc<C extends Collection> = Post<C> & {
 	updatedAt?: Timestamp;
+	deletedAt?: Timestamp;
 };
 
 export interface CreatorInfo {

--- a/src/utilities/toPost.ts
+++ b/src/utilities/toPost.ts
@@ -1,8 +1,8 @@
 import { Collection, Post, PostDoc } from '@/types/post';
 
 export const toPost = <C extends Collection>(collectionName: C, doc: PostDoc<C>): Post<C> => {
-	// updatedAt은 PostDoc에만 있고 Post에는 없으므로 제외
-	const { updatedAt: _updatedAt, ...rest } = doc;
+	// updatedAt, deletedAt은 PostDoc에만 있고 Post에는 없으므로 제외
+	const { updatedAt: _updatedAt, deletedAt: _deletedAt, ...rest } = doc;
 
 	if (collectionName === 'Communities') {
 		const communityPost = rest as unknown as Post<'Communities'>;


### PR DESCRIPTION
- postService.ts: 게시글 삭제 방식을 하드 삭제에서 소프트 삭제(deletedAt, status: 'deleted')로 변경
- postService.ts: 게시글 소프트 삭제 시 커뮤니티 스토리지 이미지 삭제 로직 추가
- usePostDetail.ts: 삭제 또는 숨김 처리된 게시글이 상세 조회되지 않도록 예외 처리
- hardDeleteExpiredPostsScheduler.ts: 삭제 후 30일이 지난 게시글과 하위 댓글/대댓글을 영구 보존 삭제하는 스케줄러 추가
- useDeletePost.ts: 게시글 삭제 후 queryClient.removeQueries 로 즉시 캐시 데이터가 지워지도록 반영
- index.ts에 존재하던 기존 사용자 게시글 복구 스케줄러를 schedulers 폴더로 구조 분리