### PR TITLE
feat: 게시글 작성/수정 개선 및 UI 수정

### DIFF
--- a/src/components/Home/PostUnit.tsx
+++ b/src/components/Home/PostUnit.tsx
@@ -98,6 +98,7 @@ const styles = StyleSheet.create({
 	},
 	thumbnail: {
 		flexShrink: 0,
+		alignSelf: 'flex-end',
 	},
 	title: {
 		flexShrink: 1,

--- a/src/hooks/post/usePostSubmit.ts
+++ b/src/hooks/post/usePostSubmit.ts
@@ -1,5 +1,5 @@
 import { showToast } from '@/components/ui/Toast';
-// import { useShowInterstitialAd } from '@/hooks/ads/useShowInterstitialAd';
+import { useShowInterstitialAd } from '@/hooks/ads/useShowInterstitialAd';
 import { goBack } from '@/navigation/RootNavigation';
 import {
 	buildCreatePostRequestParams,
@@ -19,7 +19,7 @@ export const usePostSubmit = <C extends Collection>({
 	createPost,
 	updatePost,
 }: usePostSubmitParams<C>) => {
-	// const { showAdIfReady } = useShowInterstitialAd();
+	const { showAdIfReady } = useShowInterstitialAd();
 	const buildCreatePostRequest = ({
 		collectionName,
 		imageUrls,
@@ -88,7 +88,7 @@ export const usePostSubmit = <C extends Collection>({
 			{ requestData, userId },
 			{
 				onSuccess: async (id: string) => {
-					// await showAdIfReady();
+					await showAdIfReady();
 					resetAll();
 					popToPostDetail({ postId: id, collectionName });
 					showToast('success', '게시글이 작성되었습니다.');
@@ -108,7 +108,7 @@ export const usePostSubmit = <C extends Collection>({
 		});
 		updatePost(data, {
 			onSuccess: async () => {
-				// await showAdIfReady();
+				await showAdIfReady();
 				resetAll();
 				goBack();
 				showToast('success', '게시글이 수정되었습니다.');

--- a/src/hooks/profile/form/profileFormSchema.ts
+++ b/src/hooks/profile/form/profileFormSchema.ts
@@ -14,8 +14,7 @@ export const ProfileFormSchema = z.object({
 	islandName: z
 		.string()
 		.min(2, '섬 이름을 입력해주세요.')
-		.max(10, '섬 이름은 최대 10자까지 입력 가능합니다.')
-		.regex(/^[a-zA-Z0-9가-힣\s]+$/, '섬 이름은 한글, 영문, 숫자만 가능합니다.')
+		.max(11, '섬 이름은 최대 11자까지 입력 가능합니다.')
 		.refine((name) => !cenkor(name).filtered, {
 			message: '섬 이름에 부적절한 단어가 포함되어 있습니다.',
 		})


### PR DESCRIPTION
## Summary
- 게시글 작성/수정 성공 시 전면 광고(Interstitial Ad) 노출 활성화
- 섬 이름 최대 글자수 10자 → 11자로 확대 및 특수문자 허용
- PostUnit 썸네일 alignSelf를 flex-end로 설정하여 하단 정렬

## Test plan
- [x] 게시글 작성 후 전면 광고가 노출되는지 확인
- [x] 게시글 수정 후 전면 광고가 노출되는지 확인
- [x] 11자 섬 이름 입력 가능 여부 확인
- [x] 섬 이름에 특수문자 입력 가능 여부 확인
- [x] PostUnit 썸네일 정렬 UI 확인