### PR TITLE
fix: 삭제 버튼 터치 영역 및 Algolia 조회 수 조정

### DIFF
--- a/src/components/NewPost/EditableItem.tsx
+++ b/src/components/NewPost/EditableItem.tsx
@@ -46,7 +46,11 @@ const EditableItem = ({ item, readonly = false, onDeleteItem }: EditableItemProp
 			</View>
 
 			{!readonly && onDeleteItem && (
-				<TouchableOpacity style={styles.deleteButton} onPress={() => onDeleteItem(item.id)}>
+				<TouchableOpacity
+					style={styles.deleteButton}
+					hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+					onPress={() => onDeleteItem(item.id)}
+				>
 					<FontAwesome6 name="circle-minus" size={22} color={Colors.brand.primary} />
 				</TouchableOpacity>
 			)}

--- a/src/hooks/item/query/useSearchItems.ts
+++ b/src/hooks/item/query/useSearchItems.ts
@@ -4,7 +4,7 @@ import { searchClient } from '@/config/firebase';
 import { CatalogItem } from '@/types/catalog';
 import { ItemCategory } from '@/types/post';
 
-const PAGE_SIZE = 20;
+const PAGE_SIZE = 30;
 
 interface ItemFilter {
 	category?: ItemCategory;


### PR DESCRIPTION
## Summary
- EditableItem 삭제 버튼에 hitSlop 추가하여 터치 영역 확대
- useSearchItems Algolia 한 번에 조회하는 아이템 수 20개 → 30개로 증가